### PR TITLE
docs: use caution admonition for deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-> **Deprecated:** This plugin is no longer maintained. Use [rails-fixture-complete.nvim](https://github.com/wassimk/rails-fixture-complete.nvim) instead, which supports both blink.cmp and nvim-cmp natively.
+> [!CAUTION]
+> This plugin is no longer maintained. Use [rails-fixture-complete.nvim](https://github.com/wassimk/rails-fixture-complete.nvim) instead, which supports both blink.cmp and nvim-cmp natively.
 
 # cmp-rails-fixture-types
 


### PR DESCRIPTION
## Summary
- Switch deprecation notice from plain blockquote to GitHub `[!CAUTION]` admonition